### PR TITLE
[FEATURE] QR 공유 화면 구현

### DIFF
--- a/iOS-Naduan/Resource/Info.plist
+++ b/iOS-Naduan/Resource/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>명함 QR을 인식을 지원합니다.</string>
 	<key>NSNearbyInteractionUsageDescription</key>
 	<string>로컬 네트워크를 활용하여서 무선 공유를 제공합니다.</string>
 	<key>NSNearbyInteractionAllowOnceUsageDescription</key>

--- a/iOS-Naduan/Source/Presentation/ShareScene/DropCardViewController.swift
+++ b/iOS-Naduan/Source/Presentation/ShareScene/DropCardViewController.swift
@@ -43,6 +43,12 @@ class DropCardViewController: UIViewController {
     return cardView
   }()
   
+  private let qrView: QRView = {
+    let view = QRView()
+    view.isHidden = true
+    return view
+  }()
+  
   private let viewModel: DropCardViewModel
   
   init(viewModel: DropCardViewModel) {
@@ -94,6 +100,14 @@ private extension DropCardViewController {
         dropCardFailureView.isHidden = false
         updateAdditionalAction(to: false)
         dropCardFailureView.play()
+        
+      case .didNotSupport(let cardID):
+        dropCardShareAnimationView.isHidden = true
+        dropCardSuccessView.isHidden = true
+        dropCardFailureView.isHidden = true
+        additionalActionButton.isHidden = true
+        qrView.isHidden = false
+        qrView.generateCode(cardID)
         
       case .sharing:
         dropCardShareAnimationView.isHidden = false
@@ -157,8 +171,10 @@ private extension DropCardViewController {
   }
   
   func configureHierarchy() {
-    [closeButton, dropCardShareAnimationView, dropCardSuccessView, additionalActionButton, dropCardFailureView]
-      .forEach(view.addSubview)
+    [
+      closeButton, dropCardShareAnimationView, dropCardSuccessView,
+      additionalActionButton, dropCardFailureView, qrView
+    ].forEach(view.addSubview)
   }
   
   func makeConstraints() {
@@ -194,6 +210,13 @@ private extension DropCardViewController {
       $0.leading(equalTo: view.safeAreaLayoutGuide.leadingAnchor, padding: 16)
       $0.trailing(equalTo: view.safeAreaLayoutGuide.trailingAnchor, padding: 16)
       $0.bottom(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+    }
+    
+    qrView.attach {
+      $0.top(equalTo: closeButton.bottomAnchor, padding: 16)
+      $0.leading(equalTo: view.safeAreaLayoutGuide.leadingAnchor)
+      $0.trailing(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+      $0.bottom(equalTo: additionalActionButton.topAnchor, padding: 16)
     }
   }
 }

--- a/iOS-Naduan/Source/Presentation/ShareScene/DropCardViewModel.swift
+++ b/iOS-Naduan/Source/Presentation/ShareScene/DropCardViewModel.swift
@@ -6,6 +6,7 @@
 
 enum CardShareState {
   case sharing
+  case didNotSupport(cardID: String)
   case success(BusinessCard)
   case failure
 }
@@ -29,6 +30,7 @@ class DropCardViewModel {
   
   var didReceiveCard: ((BusinessCard) -> Void)?
   var didChangeCardShareState: ((CardShareState) -> Void)?
+  var didNotSupportDevice: ((String) -> Void)?
   
   init(shareCard: BusinessCard, shareCardRepository: ShareCardRepository) {
     self.shareCard = shareCard
@@ -43,7 +45,12 @@ class DropCardViewModel {
           switch result {
             case .success(let card):
               self?.receivedCard = card
-            case .failure:
+            case .failure(let error):
+              if case ShareError.didNotSupported = error, let cardID = self?.shareCard.cardID {
+                self?.didChangeCardShareState?(.didNotSupport(cardID: cardID))
+                return
+              }
+              
               self?.didChangeCardShareState?(.failure)
           }
         }

--- a/iOS-Naduan/Source/Presentation/ShareScene/Views/QRShareView.swift
+++ b/iOS-Naduan/Source/Presentation/ShareScene/Views/QRShareView.swift
@@ -1,0 +1,99 @@
+//
+//  QRShareView.swift
+//  iOS-Naduan
+//
+//  Copyright (c) 2024 Minii All rights reserved.
+
+import UIKit
+
+class QRView: UIView {
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.font = .pretendardFont(to: .H2B)
+    label.textColor = .accent
+    label.text = "QR코드 스캐너로 읽어주세요."
+    return label
+  }()
+  
+  private let qrImageView = UIImageView()
+  
+  private let explanationLabel: Label = {
+    let padding = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+    let label = Label(padding: padding)
+    label.numberOfLines = .zero
+    label.textColor = .disable
+    label.font = .pretendardFont(to: .C1R)
+    label.layer.cornerRadius = 8
+    label.layer.backgroundColor = UIColor.gray02.cgColor
+    label.text = TextConstants.explainDescription
+    return label
+  }()
+  
+  private var filter = CIFilter(name: "CIQRCodeGenerator")
+  
+  init() {
+    super.init(frame: .zero)
+    
+    configureUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  func generateCode(_ value: String) {
+    guard let filter = filter,
+          let data = value.data(using: .isoLatin1, allowLossyConversion: false) else {
+      return
+    }
+    
+    filter.setValue(data, forKey: "inputMessage")
+    filter.setValue("M", forKey: "inputCorrectionLevel")
+    
+    guard let ciImage = filter.outputImage else { return }
+    let transformed = ciImage.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
+    self.qrImageView.image = UIImage(ciImage: transformed)
+  }
+}
+
+private extension QRView {
+  func configureUI() {
+    configureHierarchy()
+    makeConstraints()
+  }
+  
+  func configureHierarchy() {
+    [titleLabel, qrImageView, explanationLabel]
+      .forEach { addSubview($0) }
+  }
+  
+  func makeConstraints() {
+    titleLabel.attach {
+      $0.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor)
+      $0.top(equalTo: safeAreaLayoutGuide.topAnchor)
+    }
+    
+    qrImageView.attach {
+      $0.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor)
+      $0.centerYAnchor.constraint(equalTo: safeAreaLayoutGuide.centerYAnchor)
+      $0.height(equalTo: 250)
+      $0.width(equalTo: 250)
+    }
+    
+    explanationLabel.attach {
+      $0.leading(equalTo: safeAreaLayoutGuide.leadingAnchor, padding: 24)
+      $0.trailing(equalTo: safeAreaLayoutGuide.trailingAnchor, padding: 24)
+      $0.bottom(equalTo: safeAreaLayoutGuide.bottomAnchor)
+    }
+  }
+}
+
+private extension QRView {
+  enum TextConstants {
+    static let explainDescription: String = """
+    해당 기능을 지원하지 않는 기기입니다. 상대방의 기기에서 QR코드를 스캔해주세요. 상대방의 기기에서 공유가 완료되면, 자동으로 자신의 상대방의 명함이 공유됩니다.
+    
+    지원 기기 : iPhone 11 이후 모델 (SE 기종 제외)
+    """
+  }
+}

--- a/iOS-Naduan/Source/Repository/ShareCardRepository.swift
+++ b/iOS-Naduan/Source/Repository/ShareCardRepository.swift
@@ -10,6 +10,7 @@ import NearbyInteraction
 
 enum ShareError: Error {
   case notFindReceiveData
+  case didNotSupported
 }
 
 class ShareCardRepository {
@@ -30,6 +31,11 @@ class ShareCardRepository {
       self?.multiPeerSession?.sendData(to: peerID, with: cardData)
     }
     
+    guard let session = session else {
+      completion(.failure(ShareError.didNotSupported))
+      return
+    }
+    
     session.didReceiveNotDecodableData = { [weak self] data in
       guard let receivedCard = try? JSONDecoder().decode(BusinessCard.self, from: data) else {
         completion(.failure(ShareError.notFindReceiveData))
@@ -37,6 +43,11 @@ class ShareCardRepository {
       }
       
       self?.saveCardData(sendCard: card, receivedCard: receivedCard, completion: completion)
+    }
+    
+    session.didReceiveNotSupported = {
+      completion(.failure(ShareError.didNotSupported))
+      return
     }
     
     self.multiPeerSession = session

--- a/iOS-Naduan/Source/Service/NearByInteractionService.swift
+++ b/iOS-Naduan/Source/Service/NearByInteractionService.swift
@@ -17,6 +17,7 @@ struct MPCSessionConstants {
 class NearByInteractionService: NSObject {
   var didReachHandler: (MCPeerID) -> Void
   var didReceiveNotDecodableData: ((Data) -> Void)?
+  var didReceiveNotSupported: (() -> Void)?
   private let serviceID: String
   private let session: MCSession
   private let localPeerID: MCPeerID
@@ -27,7 +28,7 @@ class NearByInteractionService: NSObject {
   private let nearBySession: NISession
   private var connectedTokens: [NIDiscoveryToken: MCPeerID] = [:]
   
-  init(
+  init?(
     peerID: String,
     service: String = MPCSessionConstants.serviceID,
     identifier: String = MPCSessionConstants.keyID,
@@ -55,6 +56,16 @@ class NearByInteractionService: NSObject {
     self.didReachHandler = didReachHandler
     
     super.init()
+    
+    if #available(iOS 16.0, *) {
+      if NISession.deviceCapabilities.supportsPreciseDistanceMeasurement == false {
+        return nil
+      }
+    } else {
+      if NISession.isSupported == false {
+        return nil
+      }
+    }
     
     session.delegate = self
     mcAdvertiser.delegate = self
@@ -206,6 +217,5 @@ extension NearByInteractionService: NISessionDelegate {
   }
   
   func session(_ session: NISession, didInvalidateWith error: Error) {
-    print(error)
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#18 QR 코드 지원 화면

## 📝작업 내용
- UWB 장치를 지원하지 않는 기기에 대한 공유 화면 구현
- QR 코드 생성 메서드 구현

### 스크린샷 (선택)
![simulator_screenshot_CEB28328-6128-440A-96F4-8DAD6FE60DD6](https://github.com/f-lab-edu/iOS-Nadaun/assets/52390923/42ac8b48-0046-4987-9c58-e00da39b9084)

# 중요 내용
- NISession 타입 내에서 기기가 지원되는지 검사할 수 있었습니다.
- NISession의 Static Method이기 때문에 NearByInteractionService 타입에서 구현했습니다.
  - 실패 가능 Init을 활용하고, 실패하는 경우에 completion을 수행하도록 구현했습니다.
